### PR TITLE
Fix up several tiny grammar issues within README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@
 
 First of all, this launcher is open source, but not adjusted for the most people. What's more, the author is a student without any income or in a development team. As a result, the launcher is still at the development stage. You can suggest sone good ideas or ask your questions on the GitHub issue. Besides, our group chat always opens to you. No penny required!
 
-This precompiled launcher includes a method, using private api keys such as Microsoft AZure Client ID and CurseForge API Key, so you cannot compile this project after you clone the project. To fix it, you should add an PrivacyMethod.pas in your workspace. For further information, see Privacy.md. You also can fill an empty string value to compile a release without Microsoft OAuth or CurseForge API, without some vital functions. 
+This precompiled launcher includes a method, using private api keys such as Microsoft Azure Client ID and CurseForge API Key, so you cannot compile this project after you clone the project. To fix it, you should add an PrivacyMethod.pas in your workspace. For further information, see Privacy.md. You also can fill an empty string value to compile a release without Microsoft OAuth or CurseForge API, without some vital functions.
 
 Btw, this project do **only** support **RAD Studio Delphi** to compile it, it does not support *Lazarus* or *other compiler*.
 
-BBtw, if you want to support the author so that the author can have a good meal, you can donate on Afdian. However, if you are only a child or a worker without a fixed income source, you are absolutely not allowed to give money for me, which may cause a serious impact.
+Additionally, if you want to support the author so that the author can have a good meal, you can donate on Afdian. However, if you are only a child or a worker without a fixed income source, you are absolutely not allowed to give money for me, which may cause a serious impact.
 
 My afdian website is: [Rechalow](https://afdian.net/a/Rechalow)
 
-~Oh by by the way, this launcher is written in the language Delphi. If you are worried that this launcher contains viruses, you can unpack this launcher or do researches on the code. This launcher does not contain any virus and will not cause any damage to the computer.~ No virus risks with your code reviews!
+~Oh by the way, this launcher is written in the language Delphi. If you are worried that this launcher contains viruses, you can unpack this launcher or do researches on the code. This launcher does not contain any virus and will not cause any damage to the computer.~ No virus risks with your code reviews!
 
-This launcher call name "Little Limbo Launcher", You also can call it "LaLaLa Launcher". It is up to you. Just enjoy it!
+This launcher is called with the name "Little Limbo Launcher". You also can call it "LaLaLa Launcher". It is up to you. Just enjoy it!
 
 For further information related to the license, see [LICENSE](./LICENSE)
 
@@ -49,4 +49,4 @@ As soon as I have some snapshot version, I will release it in my group that not 
 (Release version): [lanzou click me](https://wwdy.lanzouj.com/b023j206d) password: 90y9
 
 - from now on, there are **no private snapshot** version and snapshot version in here, I will release all version in *public* version, thanks!
-- at the same time, I archived my all private version for everyone to read. Fot older releases, please check the Chinese Readme!
+- at the same time, I archived all of my private versions for everyone to read. Fot older releases, please check the Chinese Readme!


### PR DESCRIPTION
The following aspects of grammar within README.md are discovered by myself accidentally, and consequently got polished by hand on my own:

1. "Microsoft AZure" -> "Microsoft Azure"
2. "BBtw" -> "Additionally" since the use of "BBtw" is regarded as informal. It can not be found in dictionary, either.
3. Among "Oh by by the way" the preposition "by" is duplicated, hence the repeated one was removed.
4. "This launcher call name" is thoroughly wrong in English. The genuine expression is supposed to be "This launcher is called with the name".
5. "my all private version" -> "all of my private versions"

Suggestions are given above. Looking forward to future performance on the development of lllauncher. :)